### PR TITLE
Utilisation de l'authentification Feathers dans le client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "@fancyapps/fancybox": "^3.5.7",
-    "@feathersjs/client": "^4.5.9",
+    "@feathersjs/authentication-client": "^4.5.10",
+    "@feathersjs/feathers": "^4.5.10",
     "@feathersjs/socketio-client": "^4.5.9",
     "@fortawesome/fontawesome-free": "^5.15.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -27,18 +27,22 @@ export default class App extends Vue  {
 
     user: User | null = null;
 
-    beforeUpdate() {
-        this.user = app.get('user');
+    private beforeUpdate() {
+        const storedUser = localStorage.getItem('user');
+        if (storedUser)
+            this.user = JSON.parse(storedUser);
+        else
+            this.user = null;
     }
 
     public logOut = async () => {
         await app.logout();
-        app.set('user', null);
+        localStorage.removeItem('user');
 
         try {
             await this.$router.replace('/');
         } catch (err) {
-            null;
+            // pass
         }
     }
 

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -27,34 +27,21 @@ export default class App extends Vue  {
 
     user: User | null = null;
 
-    mounted() {
-        this.user = this.getUser();
-    }
-
     beforeUpdate() {
-        if (!this.user) {
-            this.user = this.getUser();
+        this.user = app.get('user');
+    }
+
+    public logOut = async () => {
+        await app.logout();
+        app.set('user', null);
+
+        try {
+            await this.$router.replace('/');
+        } catch (err) {
+            null;
         }
     }
 
-    getUser(): User | null {
-        const authFromStorage = JSON.parse(window.localStorage.getItem('user')!);
-        if (authFromStorage) {
-            app.authentication.setAccessToken(authFromStorage.accessToken);
-            app.authenticate();
-            const userFromStorage = authFromStorage.user;
-            return new User(userFromStorage.id, userFromStorage.email, userFromStorage.firstname, userFromStorage.lastname,
-                userFromStorage.isGodfather, userFromStorage.isAdmin);
-        } else {
-            return null;
-        }
-    }
-
-    logOut() {
-        app.logout();
-        window.localStorage.removeItem('user');
-        this.user = null;
-    }
 }
 </script>
 

--- a/client/src/components/MenuParrain7.vue
+++ b/client/src/components/MenuParrain7.vue
@@ -23,13 +23,13 @@
                         <router-link class="nav-link" to="/answers">Réponses</router-link>
                     </li>
                     <li class="nav-item " v-if="this.isGodfather()">
-                        <router-link class="nav-link" to="/rankings">Choix des poulains</router-link>
+                        <router-link class="nav-link" to="/rankings">Choix des filleuls</router-link>
                     </li>
                     <li class="nav-item " v-if="this.isAdmin()">
                         <router-link class="nav-link" to="/users">Gestion utilisateurs</router-link>
                     </li>
                     <li class="nav-item ">
-                        <router-link class="nav-link" to="/about">A propos</router-link>
+                        <router-link class="nav-link" to="/about">À propos</router-link>
                     </li>
                     <!-- <li class="nav-item dropdown dropdown-animate" data-toggle="hover">
                         <a class="nav-link" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Pages</a>
@@ -45,11 +45,7 @@
                         <a class="nav-link" href="docs/index.html">Docs</a>
                     </li> -->
                 </ul>
-                <!-- Button -->
-                <!--a class="navbar-btn btn btn-sm btn-primary d-none d-lg-inline-block ml-3" href="https://github.com/webpixels/quick-website-ui-kit-demo/archive/master.zip">
-                    Download Free
-                </a-->
-                <router-link class=" btn btn-sm btn-primary d-lg-inline-block" to="/login" v-if="!this.user">
+                <router-link class="btn btn-sm btn-primary d-lg-inline-block" to="/login" v-if="!this.user">
                     Connexion
                 </router-link>
                 <button class="btn btn-sm btn-danger d-lg-inline-block" v-if="this.user" @click="signalLogOut">
@@ -69,10 +65,6 @@ export default class MenuParrain7 extends Vue {
 
     @Prop() user?: User | null;
 
-    mounted() {
-        // console.log(this.user);
-    }
-
     isAdmin(): boolean {
         return !!this.user && this.user.isAdmin;
     }
@@ -86,7 +78,6 @@ export default class MenuParrain7 extends Vue {
     }
 
     signalLogOut() {
-        // console.log("Deco moi pls");
         this.$emit('signalLogOut');
     }
 

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -4,6 +4,11 @@ const BACKEND_DICT: { [mode: string]: string } = {
     production: 'parrai-n-7-app.feathersjs.com'
 };
 
-const BACKEND_URL: string = BACKEND_DICT[ process.env.VUE_APP_MODE ] || BACKEND_DICT['default'];
+let BACKEND_URL: string;
+if (process.env.VUE_APP_MODE) {
+    BACKEND_URL = BACKEND_DICT[process.env.VUE_APP_MODE];
+} else {
+    BACKEND_URL = BACKEND_DICT['default'];
+}
 
 export default BACKEND_URL;

--- a/client/src/feathers-client.ts
+++ b/client/src/feathers-client.ts
@@ -1,16 +1,17 @@
-/* eslint @typescript-eslint/no-var-requires: "off" */
 
 import BACKEND_URL from '@/config';
+import feathers from '@feathersjs/feathers';
+import auth from '@feathersjs/authentication-client';
+import socketio from '@feathersjs/socketio-client';
 import io from 'socket.io-client';
-const feathers = require('@feathersjs/client'); // bug in feathers-client module
 
 const socket = io(BACKEND_URL);
-
 const app = feathers();
-app.configure(feathers.socketio(socket));
-app.configure(feathers.authentication({
-    //storageKey: 'auth'
-    storage: window.localStorage
+app.configure(socketio(socket));
+app.configure(auth({
+    storage: window.localStorage,
+    storageKey: 'access-token',
+    path: '/authentication'
 }));
 
 export default app;

--- a/client/src/views/LogIn.vue
+++ b/client/src/views/LogIn.vue
@@ -24,7 +24,7 @@
                                            @keyup="handleKeyUp" @blur="checkError"/>
 
                                     <div class="input-group-append">
-                                        <span class="input-group-text">@etu.toulouse-inp.fr</span>
+                                        <span class="input-group-text">{{institutionalEmailEnd}}</span>
                                     </div>
                                 </div>
                             </div>
@@ -74,8 +74,7 @@ import app from "@/feathers-client";
 @Component
 export default class LogIn extends Vue {
 
-    private institutionalEmailRegexp =
-        RegExp('^\\w+\\.\\w+@etu\\.toulouse-inp\\.fr$');
+    private institutionalEmailEnd = '@etu.toulouse-inp.fr';
 
     private loginForm = {
         email: '',
@@ -88,27 +87,23 @@ export default class LogIn extends Vue {
 
         this.loginForm.errorMessage = 'Connectez-vous à votre compte pour continuer';
         this.loginForm.hasError = false;
-        app.logout();
-        const auth = await app.authenticate({
-            strategy: 'local',
-            email: this.loginForm.email + '@etu.toulouse-inp.fr',
-            password: this.loginForm.password,
-        }).then(
-            (data: any) => {
-                window.localStorage.setItem('user', JSON.stringify(data));
-                this.loginForm.email = '';
-                this.loginForm.password = '';
-                this.$router.push('questions');
-            }
-        ).catch( (error: any) => {
-            if (error.code === 401) {
-                // console.log("mauvais mdp");
+        await app.logout();
+        try {
+            const auth = await app.authenticate({
+                strategy: 'local',
+                email: this.loginForm.email + this.institutionalEmailEnd,
+                password: this.loginForm.password
+            });
+            app.set('user', auth.user);
+            this.loginForm.email = '';
+            this.loginForm.password = '';
+            await this.$router.push('questions');
+        } catch (err) {
+            if (err.code === 401) {
                 this.loginForm.errorMessage = 'Utilisateur ou mot de passe incorrect.';
                 this.loginForm.hasError = true;
             }
-        });
-
-        return auth;
+        }
 
     }
 
@@ -135,7 +130,7 @@ export default class LogIn extends Vue {
         }
         */
         if (e.keyCode === 13) {
-            this.logIn()
+            this.logIn();
         } else {
             this.noError();
         }

--- a/client/src/views/LogIn.vue
+++ b/client/src/views/LogIn.vue
@@ -94,7 +94,7 @@ export default class LogIn extends Vue {
                 email: this.loginForm.email + this.institutionalEmailEnd,
                 password: this.loginForm.password
             });
-            app.set('user', auth.user);
+            localStorage.setItem('user', JSON.stringify(auth.user));
             this.loginForm.email = '';
             this.loginForm.password = '';
             await this.$router.push('questions');

--- a/client/src/views/SignUp.vue
+++ b/client/src/views/SignUp.vue
@@ -107,7 +107,7 @@
                         </form>
                     </div>
                     <div class="card-footer px-md-5"><small>Déjà enregistré ?</small>
-                        <router-link to="/login" class="small font-weight-bold"> Connectez-vous</router-link>
+                        <router-link to="/login" class="small font-weight-bold"> Connectez-vous.</router-link>
                     </div>
                 </div>
             </div>

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -15,8 +15,8 @@
       "header": {
         "typ": "access"
       },
-      "audience": "https://yourdomain.com",
-      "issuer": "feathers",
+      "audience": "https://parrai-n-7-app.feathersjs.com",
+      "issuer": "ParraiN7",
       "algorithm": "HS256",
       "expiresIn": "1d"
     },

--- a/server/src/authentication.ts
+++ b/server/src/authentication.ts
@@ -1,7 +1,6 @@
 import {ServiceAddons} from '@feathersjs/feathers';
 import {AuthenticationService, JWTStrategy} from '@feathersjs/authentication';
 import {LocalStrategy} from '@feathersjs/authentication-local';
-import {expressOauth} from '@feathersjs/authentication-oauth';
 
 import {Application} from './declarations';
 
@@ -18,5 +17,4 @@ export default function (app: Application): void {
     authentication.register('local', new LocalStrategy());
 
     app.use('/authentication', authentication);
-    app.configure(expressOauth());
 }


### PR DESCRIPTION
Grosse simplification de l'authentification en utilisant les méthodes fournies par Feathers :
- appel de app.authenticate() qui store un token caché du nom de "access-token"
- stockage de l'utilisateur courant dans un token "user", si ce token est volé par quelqu'un, il pourra voir le site comme si il était la personne qu'il a volé mais le backend ne répondra pas (il ne sera pas authentifié auprès du server feathers)
- suppresion de beaucoup de méthodes devenues inutiles